### PR TITLE
VOICISUC-4298 startActivity() from outside of an Activity context requires the  FLAG_ACTIVITY_NEW_TASK

### DIFF
--- a/src/android/FCMPlugin.java
+++ b/src/android/FCMPlugin.java
@@ -151,6 +151,7 @@ public class FCMPlugin extends CordovaPlugin {
 			JSONObject jo = new JSONObject();
 			String callBack;
 			for (String key: payload.keySet()) {
+				Log.i(TAG, "payload.get(key) ---- " + payload.get(key).toString());
 				if (payload.get(key).toString().equals("CALL") && isResumed != true) {
 					if (isPaused == true || isDestroyed == true) {
 						jo.put("isPaused", true);
@@ -167,7 +168,7 @@ public class FCMPlugin extends CordovaPlugin {
 							Log.d(TAG, "RESUMING ACTIVITY");
 							Intent startIntent = new Intent(context, FCMPluginActivity.class);
 							startIntent.setAction(Intent.ACTION_MAIN);
-							startIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+							startIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 							context.startActivity(startIntent);
 						}
 					}					


### PR DESCRIPTION
error obtain when the user sends his app to background and receives a call

> D/FCMPlugin: ERROR sendPushToView. SAVED NOTIFICATION: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?08-21 10:31:02.149 20557-21289/com.itcenter.businesshostedvoice.ist D/FCMPlugin: ERROR sendPushToView. SAVED NOTIFICATION: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?

 what the user sees, the ringing tone is emitted but the app doesn't come to the foreground. 

This issue was only when the app was on background state. App on the destroyed state the required flag is added to the Intent.

